### PR TITLE
Update VIP-specific descriptor checks

### DIFF
--- a/vipapps/vipapps.py
+++ b/vipapps/vipapps.py
@@ -174,13 +174,18 @@ def load_descriptor(filepath, silent=False) -> dict:
         rawtext = f.read()
         f.seek(0)
         desc = json.load(f)
+        # VIP-specific checks, in addition to "bosh validate".
+        # These rules should be kept similar to those in VIP-portal/BoutiquesParser.java.
         appname = desc["name"]
         appversion = desc["tool-version"]
-        # check name and version strings
-        if not re.match(r"^[a-zA-Z0-9_\. +-]+$", appname):
+        # check mandatory fields, and name+version content
+        if not re.match(r"^[a-zA-Z0-9_\.@ +-]+$", appname):
             raise ValueError("invalid name '%s'" % appname)
         if not re.match(r"^[a-zA-Z0-9_\.@ +-]+$", appversion):
             raise ValueError("invalid version '%s'" % appversion)
+        # author field mandatory
+        if "author" not in desc:
+            raise ValueError("%s: missing author" % filepath)
         # check container-image (just warnings)
         if not silent:
             if not "container-image" in desc:


### PR DESCRIPTION
This is a sibling PR to https://github.com/virtual-imaging-platform/VIP-portal/pull/577, which harmonizes the VIP-specific checks done on top of `bosh validate`, when importing a descriptor in either VIP-portal web UI or with `vipapps.py` command-line.

The lack of a check on the `author` field in `vipapps.py` caused the `Coil_Characterization-3.3.json` descriptor to be imported without such a field during the migration last week, which would have been rejected if UI import had been used : this has been fixed in https://github.com/virtual-imaging-platform/vip-apps-boutiques-descriptors/commit/2a590fe4b3e17a75b4b42f1e4d6473e5402fd0a8, this descriptor should be re-imported for consistency.

A remaining difference between these two implementations is that VIP-portal does some checks on the `vip:dot` custom property, while `vipapps.py` doesn't. These checks are rather incomplete anyway compared to the [custom properties](https://github.com/virtual-imaging-platform/VIP-portal/wiki/Advanced-boutiques-descriptors) that are actually implemented, so some upcoming decision remains on :
- whether or not we want to check custom properties at import-time
- whether or not the induced implementations should be factorized between VIP-portal and `vipapps.py` : in theory this could be done by either having VIP-portal expose a descriptor validation API that `vipapps.py` would call (single Java implementation in VIP-portal), or by having a command-line descriptor check implemented in VIP-python-client that VIP-portal would call in addition to `bosh validate` (single Python implementation in VIP-python-client, packaging TBD)
